### PR TITLE
fix for #23

### DIFF
--- a/cpv/_common.py
+++ b/cpv/_common.py
@@ -158,7 +158,11 @@ def pool_sig():
 # from aljunberg:  https://gist.github.com/aljungberg/626518 
 from multiprocessing.pool import IMapIterator
 def wrapper(func):
-    def wrap(self, timeout=threading.TIMEOUT_MAX):
+    def wrap(self, timeout=None):
+        try:
+            timeout = threading.TIMEOUT_MAX
+        except AttributeError:
+            timeout = 1e100
         return func(self, timeout=timeout)
     return wrap
 IMapIterator.next = wrapper(IMapIterator.next)


### PR DESCRIPTION
I also had the error reported in issue #23 with python 2.7.15 and found that not all versions (python < 3.2) of threading support TIMEOUT_MAX.