### PR TITLE
issue with multiprocessing on MacOS with Python3.8

### DIFF
--- a/cpv/acf.py
+++ b/cpv/acf.py
@@ -87,6 +87,8 @@ def acf(fnames, lags, col_num0, partial=True, simple=False, mlog=True):
     implementation.
     """
     # reversing allows optimization below.
+    from multiprocessing import set_start_method
+    set_start_method("fork", force=True)
     imap = get_map()
 
     arg_list = [] # chaining


### PR DESCRIPTION
I faced the problem running comb-p from Python3.8 on OSX. Python3.8 on OSX uses by default "spawn" start method for new processes that provides error. The workaround is to call set_start_methos with "fork" and "force" arguments: set_start_method("fork", force=True). It helped me to resolve the issue.