### PR TITLE
code pval upon float64

### DIFF
--- a/cpv/slk.py
+++ b/cpv/slk.py
@@ -70,8 +70,8 @@ def slk_chrom(chromlist, lag_max, acfs, z=True):
     arr = np.empty((len(chromlist),),  dtype=np.dtype([
         ('start', np.uint32),
         ('end', np.uint32),
-        ('p', np.float32),
-        ('slk_p', np.float32)]))
+        ('p', np.float64),
+        ('slk_p', np.float64)]))
 
     for i, (xbed, xneighbors) in enumerate(walk(chromlist, lag_max)):
 


### PR DESCRIPTION
Dear Brent, 

Thank you or your huge work.
Since strongly methylome associated phenotype (like age) generates indecently low p-values, it is better to code it on a float64 than on a float32.  Isn't it ?

Best regards,